### PR TITLE
tweak/RRV-9: Increase distance threshold so autoplays earlier

### DIFF
--- a/replace-reddit-video.js
+++ b/replace-reddit-video.js
@@ -57,7 +57,7 @@ function enableFeedAutoplay() {
                 let videoElemOffsetTop = videoElem.getBoundingClientRect().top;
 
                 let videoSelected = false;
-                if (!isOnCommentsPage() && !videoSelected && videoElemOffsetTop > 0 && videoElemOffsetTop < windowHeight * 0.35) {
+                if (!isOnCommentsPage() && !videoSelected && videoElemOffsetTop > 0 && videoElemOffsetTop < windowHeight * 0.4) {
                     videoElem.play();
                     videoSelected = true;
                 } else {


### PR DESCRIPTION
Increase distance from top threshold so element doesn't have to be as high up on the page to start autoplaying